### PR TITLE
Made test for encoding/decoding keys

### DIFF
--- a/client/src/keys/keys.go
+++ b/client/src/keys/keys.go
@@ -73,3 +73,19 @@ func GetKey(filename string) (*ecdsa.PrivateKey, error) {
 	// Returns private key
 	return privateKey, err
 }
+
+/*
+EncodePublicKey encodes given public key and returns its
+PEM-Encoded byte slice form
+*/
+func EncodePublicKey(key *ecdsa.PublicKey) []byte {
+	return []byte{}
+}
+
+/*
+DecodePublicKey takes a PEM-Encoded key and returns
+an ecdsa PublicKey Struct
+*/
+func DecodePublicKey(key []byte) ecdsa.PublicKey {
+	return ecdsa.PublicKey{}
+}

--- a/client/src/keys/keys_test.go
+++ b/client/src/keys/keys_test.go
@@ -6,6 +6,8 @@ import (
 	"crypto/rand"
 	"os"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestKeys(t *testing.T) {
@@ -20,26 +22,41 @@ func TestKeys(t *testing.T) {
 		t.Errorf("Failed to store keys.")
 	}
 
-    // actual key
-    actualPrivKey, err := GetKey(testFile)
-    if err != nil {
-        t.Errorf("Failed to retrieve keys")
-    } 
+	// actual key
+	actualPrivKey, err := GetKey(testFile)
+	if err != nil {
+		t.Errorf("Failed to retrieve keys")
+	}
 
-    // Gets the Public Keys from the Private Keys
-    actualPublicKey := actualPrivKey.PublicKey
-    expectedPublicKey := expectedPrivKey.PublicKey
+	// Gets the Public Keys from the Private Keys
+	actualPublicKey := actualPrivKey.PublicKey
+	expectedPublicKey := expectedPrivKey.PublicKey
 
-  	// Compares the D field of the Private Keys
-    if actualPrivKey.D.Cmp(expectedPrivKey.D) != 0 {
-    	t.Errorf("Private Key from file does not match expected Private Key.")
-    }
+	// Compares the D field of the Private Keys
+	if actualPrivKey.D.Cmp(expectedPrivKey.D) != 0 {
+		t.Errorf("Private Key from file does not match expected Private Key.")
+	}
 
-    // Compares the Big Ints inside of the Public Key field
-    if actualPublicKey.X.Cmp(expectedPublicKey.X) != 0 || actualPublicKey.Y.Cmp(expectedPublicKey.Y) != 0 {
-        t.Errorf("Public Key from file does not match expected Public Key.")
-    }
+	// Compares the Big Ints inside of the Public Key field
+	if actualPublicKey.X.Cmp(expectedPublicKey.X) != 0 || actualPublicKey.Y.Cmp(expectedPublicKey.Y) != 0 {
+		t.Errorf("Public Key from file does not match expected Public Key.")
+	}
 
 	// Delete testFile
 	os.Remove(testFile)
+}
+
+// Full test for encoding/decoding public keys
+func TestEncoding(t *testing.T) {
+	private, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	public := private.PublicKey
+	encoded := EncodePublicKey(&public)
+	decoded := DecodePublicKey(encoded)
+	if !cmp.Equal(public, decoded) {
+		t.Errorf("Keys do not match")
+	}
+	reEncoded := EncodePublicKey(&decoded)
+	if !cmp.Equal(reEncoded, encoded) {
+		t.Errorf("Encoded keys do not match")
+	}
 }

--- a/producer/src/keys/keys.go
+++ b/producer/src/keys/keys.go
@@ -73,3 +73,19 @@ func GetKey(filename string) (*ecdsa.PrivateKey, error) {
 	// Returns private key
 	return privateKey, err
 }
+
+/*
+EncodePublicKey encodes given public key and returns its
+PEM-Encoded byte slice form
+*/
+func EncodePublicKey(key *ecdsa.PublicKey) []byte {
+	return []byte{}
+}
+
+/*
+DecodePublicKey takes a PEM-Encoded key and returns
+an ecdsa PublicKey Struct
+*/
+func DecodePublicKey(key []byte) ecdsa.PublicKey {
+	return ecdsa.PublicKey{}
+}

--- a/producer/src/keys/keys_test.go
+++ b/producer/src/keys/keys_test.go
@@ -6,6 +6,8 @@ import (
 	"crypto/rand"
 	"os"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestKeys(t *testing.T) {
@@ -20,26 +22,41 @@ func TestKeys(t *testing.T) {
 		t.Errorf("Failed to store keys.")
 	}
 
-    // actual key
-    actualPrivKey, err := GetKey(testFile)
-    if err != nil {
-        t.Errorf("Failed to retrieve keys")
-    } 
+	// actual key
+	actualPrivKey, err := GetKey(testFile)
+	if err != nil {
+		t.Errorf("Failed to retrieve keys")
+	}
 
-    // Gets the Public Keys from the Private Keys
-    actualPublicKey := actualPrivKey.PublicKey
-    expectedPublicKey := expectedPrivKey.PublicKey
+	// Gets the Public Keys from the Private Keys
+	actualPublicKey := actualPrivKey.PublicKey
+	expectedPublicKey := expectedPrivKey.PublicKey
 
-  	// Compares the D field of the Private Keys
-    if actualPrivKey.D.Cmp(expectedPrivKey.D) != 0 {
-    	t.Errorf("Private Key from file does not match expected Private Key.")
-    }
+	// Compares the D field of the Private Keys
+	if actualPrivKey.D.Cmp(expectedPrivKey.D) != 0 {
+		t.Errorf("Private Key from file does not match expected Private Key.")
+	}
 
-    // Compares the Big Ints inside of the Public Key field
-    if actualPublicKey.X.Cmp(expectedPublicKey.X) != 0 || actualPublicKey.Y.Cmp(expectedPublicKey.Y) != 0 {
-        t.Errorf("Public Key from file does not match expected Public Key.")
-    }
+	// Compares the Big Ints inside of the Public Key field
+	if actualPublicKey.X.Cmp(expectedPublicKey.X) != 0 || actualPublicKey.Y.Cmp(expectedPublicKey.Y) != 0 {
+		t.Errorf("Public Key from file does not match expected Public Key.")
+	}
 
 	// Delete testFile
 	os.Remove(testFile)
+}
+
+// Full test for encoding/decoding public keys
+func TestEncoding(t *testing.T) {
+	private, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	public := private.PublicKey
+	encoded := EncodePublicKey(&public)
+	decoded := DecodePublicKey(encoded)
+	if !cmp.Equal(public, decoded) {
+		t.Errorf("Keys do not match")
+	}
+	reEncoded := EncodePublicKey(&decoded)
+	if !cmp.Equal(reEncoded, encoded) {
+		t.Errorf("Encoded keys do not match")
+	}
 }


### PR DESCRIPTION
**Expected Date of Completion:** 15-March-2019

**Workspace:**
- `producer/src/keys/keys.go`
- `producer/src/keys/keys_test.go`
- `client/src/keys/keys.go`
- `client/src/keys/keys_test.go`

**Objective:**
We will need a function that returns an invertible form of the public key struct that is provided by the `ecdsa` package. In some instances the structs will need to be hashed, and our hash function can only take in `byte` slices. Look at the existing `keys` functions for guidance on how to encode keys.

**Testing:**
Make sure the test in `keys_test.go` passes. 

**Resources:**
- [Go ecdsa](https://golang.org/pkg/crypto/ecdsa/)
