### PR TITLE
Fixed deserialize bug

### DIFF
--- a/producer/src/block/block.go
+++ b/producer/src/block/block.go
@@ -110,17 +110,22 @@ func Deserialize(block []byte) Block {
 	for i := 0; i < int(dataLen); i++ { // deserialize each individual element in Data
 		elementLen := int(block[index])
 		index += 2
-		data[i] = block[index : index+elementLen]
+		data[i] = make([]byte, elementLen)
+		copy(data[i], block[index:index+elementLen])
 		index += elementLen
 	}
 
+	previousHash := make([]byte, 32)
+	merkleRootHash := make([]byte, 32)
+	copy(previousHash, block[20:52])
+	copy(merkleRootHash, block[52:84])
 	// initialize the deserialized block
 	deserializeBlock := Block{
 		Version:        binary.LittleEndian.Uint32(block[0:4]),
 		Height:         binary.LittleEndian.Uint64(block[4:12]),
 		Timestamp:      int64(binary.LittleEndian.Uint64(block[12:20])),
-		PreviousHash:   block[20:52],
-		MerkleRootHash: block[52:84],
+		PreviousHash:   previousHash,
+		MerkleRootHash: merkleRootHash,
 		DataLen:        dataLen,
 		Data:           data,
 	}

--- a/producer/src/block/block_test.go
+++ b/producer/src/block/block_test.go
@@ -3,9 +3,10 @@ package block
 import (
 	"bytes"           // for comparing []bytes
 	"encoding/binary" // for encoding/decoding
-	"reflect"         // to get data type
-	"testing"         // testing
-	"time"            // to get time stamp
+	"fmt"
+	"reflect" // to get data type
+	"testing" // testing
+	"time"    // to get time stamp
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -177,4 +178,14 @@ func TestDeserialize(t *testing.T) {
 	if !cmp.Equal(expected, actual) {
 		t.Errorf("Blocks do not match")
 	}
+	fmt.Printf("%v\n", intermed)
+	fmt.Printf("actual.Height: %v\n", actual.Height)
+	//change itermed to see if that changes the deserialized block
+	intermed[21] = uint8(21)
+	fmt.Printf("%v\n", intermed)
+	fmt.Printf("actual.Height: %v\n", actual.Height)
+	if !cmp.Equal(expected, actual) {
+		t.Errorf("Blocks do not match")
+	}
+
 }

--- a/producer/src/block/block_test.go
+++ b/producer/src/block/block_test.go
@@ -3,10 +3,9 @@ package block
 import (
 	"bytes"           // for comparing []bytes
 	"encoding/binary" // for encoding/decoding
-	"fmt"
-	"reflect" // to get data type
-	"testing" // testing
-	"time"    // to get time stamp
+	"reflect"         // to get data type
+	"testing"         // testing
+	"time"            // to get time stamp
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -178,12 +177,10 @@ func TestDeserialize(t *testing.T) {
 	if !cmp.Equal(expected, actual) {
 		t.Errorf("Blocks do not match")
 	}
-	fmt.Printf("%v\n", intermed)
-	fmt.Printf("actual.Height: %v\n", actual.Height)
+
 	//change itermed to see if that changes the deserialized block
 	intermed[21] = uint8(21)
-	fmt.Printf("%v\n", intermed)
-	fmt.Printf("actual.Height: %v\n", actual.Height)
+	intermed[54] = uint8(21)
 	if !cmp.Equal(expected, actual) {
 		t.Errorf("Blocks do not match")
 	}

--- a/producer/src/contract/contract.go
+++ b/producer/src/contract/contract.go
@@ -2,6 +2,7 @@ package contract
 
 import (
 	"crypto/ecdsa"
+	"encoding/binary"
 	"errors"
 
 	"github.com/SIGBlockchain/project_aurum/producer/src/keys"
@@ -35,7 +36,10 @@ func InsertYield(y Yield, database string, blockHeight uint32, contractHash []by
 
 /* Serialize ... serialies the yield */
 func (y *Yield) Serialize() []byte {
-	return []byte{}
+	s := make([]byte, 40) //32 bytes for hash and 8 bytes for value
+	copy(s[0:32], y.Recipient)
+	binary.LittleEndian.PutUint64(s[32:40], y.Value)
+	return s
 }
 
 /* DeserializeYield ... deserializes the yield */

--- a/producer/src/contract/contract.go
+++ b/producer/src/contract/contract.go
@@ -3,6 +3,8 @@ package contract
 import (
 	"crypto/ecdsa"
 	"errors"
+
+	"github.com/SIGBlockchain/project_aurum/producer/src/keys"
 )
 
 /* Yield ... Contains a 32 size byte slice recipient, and a uint64 value */
@@ -12,8 +14,8 @@ type Yield struct {
 }
 
 /* Make Yield ... Recipient will be SHA-256 hashed */
-func MakeYield(recipient ecdsa.PublicKey, value uint64) Yield {
-	return Yield{}
+func MakeYield(recipient *ecdsa.PublicKey, value uint64) Yield {
+	return Yield{Recipient: keys.EncodePublicKey(recipient), Value: value}
 }
 
 /* Inserts Yield into database */


### PR DESCRIPTION
I noticed a bug in the deserialize function for block. If the byte slice has value changed after the deserailize function is called, the deserialized block also changes its value. This happens in the deserialize function, references were copied, rather than copying bytes. 