### PR TITLE
Configured travis to skip main packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+gobuild_args: `go list ./... | grep -v main` -v
+
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-gobuild_args: `go list ./... | grep -v main` -v
-
 language: go
 
 go:
 - master
+
+gobuild_args: `go list ./... | grep -v main` -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ language: go
 go:
 - master
 
-gobuild_args: `go list ./... | grep -v main` -v
+gobuild_args: `go list ./... | grep -v main`
+
+script: go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,4 @@ language: go
 go:
 - master
 
-gobuild_args: `go list ./... | grep -v main`
-
-script: go test -v ./...
+script: go test `go list ./... | grep -v main` -v ./...


### PR DESCRIPTION
Prior to this, travis would test main packages despite them not having test files. Now it will skip over those packages with the new travis script.