### PR TITLE
completed issue 324

### DIFF
--- a/internal/hashing/hashing_test.go
+++ b/internal/hashing/hashing_test.go
@@ -20,18 +20,16 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestGetMerkleRootHashEmptyInput(t *testing.T) {
+func TestGetMerkleRootHashInput(t *testing.T) {
 	input := [][]byte{}
-	result := GetMerkleRootHash(input)
+	expected := GetMerkleRootHash(input)
 
-	if len(input) != len(result) {
+	if len(input) != len(expected) {
 		t.Errorf("Error! GetMerkelRootHash does not return an empty slice on input of empty slice")
 	}
-}
 
-func TestGetMerkleRootHashSinlgeInput(t *testing.T) {
-	input := [][]byte{[]byte("transaction")}
-	expected := New(New(input[0]))
+	input = [][]byte{[]byte("transaction")}
+	expected = New(New(input[0]))
 	actual := GetMerkleRootHash(input)
 
 	if !bytes.Equal(expected, actual) {
@@ -39,41 +37,35 @@ func TestGetMerkleRootHashSinlgeInput(t *testing.T) {
 		t.Errorf("Expected != Actual")
 		t.Errorf("%v != %v", expected, actual)
 	}
-}
 
-func TestGetMerkleRootHashDoubleInput(t *testing.T) {
-	input := [][]byte{[]byte("transaction1"), []byte("transaction2")}
+	input = [][]byte{[]byte("transaction1"), []byte("transaction2")}
 	concat := append(New(New(input[0])), New(New(input[1]))...)
-	expected := New(New(concat))
-	actual := GetMerkleRootHash(input)
+	expected = New(New(concat))
+	actual = GetMerkleRootHash(input)
 
 	if !bytes.Equal(expected, actual) {
 		t.Errorf("Error! GetMerkelRootHash does not produce correct result on two byte slices")
 		t.Errorf("Expected != Actual")
 		t.Errorf("%v != %v", expected, actual)
 	}
-}
 
-func TestGetMerkleRootHashTripleInput(t *testing.T) {
-	input := [][]byte{[]byte("transaction1"), []byte("transaction2"), []byte("transaction3")}
+	input = [][]byte{[]byte("transaction1"), []byte("transaction2"), []byte("transaction3")}
 	concat1 := New(New(append(New(New(input[0])), New(New(input[1]))...)))
 	concat2 := New(New(append(New(New(input[2])), New(New(input[2]))...)))
-	expected := New(New(append(concat1, concat2...)))
-	actual := GetMerkleRootHash(input)
+	expected = New(New(append(concat1, concat2...)))
+	actual = GetMerkleRootHash(input)
 
 	if !bytes.Equal(expected, actual) {
 		t.Errorf("Error! GetMerkelRootHash does not produce correct result on three byte slices")
 		t.Errorf("Expected != Actual")
 		t.Errorf("%v != %v", expected, actual)
 	}
-}
 
-func TestGetMerkleRootHashQuadInput(t *testing.T) {
-	input := [][]byte{[]byte("transaction1"), []byte("transaction2"), []byte("transaction3"), []byte("transaction4")}
-	concat1 := New(New(append(New(New(input[0])), New(New(input[1]))...)))
-	concat2 := New(New(append(New(New(input[2])), New(New(input[3]))...)))
-	expected := New(New(append(concat1, concat2...)))
-	actual := GetMerkleRootHash(input)
+	input = [][]byte{[]byte("transaction1"), []byte("transaction2"), []byte("transaction3"), []byte("transaction4")}
+	concat1 = New(New(append(New(New(input[0])), New(New(input[1]))...)))
+	concat2 = New(New(append(New(New(input[2])), New(New(input[3]))...)))
+	expected = New(New(append(concat1, concat2...)))
+	actual = GetMerkleRootHash(input)
 
 	if !bytes.Equal(expected, actual) {
 		t.Errorf("Error! GetMerkelRootHash does not produce correct result on three byte slices")

--- a/internal/hashing/hashing_test.go
+++ b/internal/hashing/hashing_test.go
@@ -25,47 +25,41 @@ func TestGetMerkleRootHashInput(t *testing.T) {
 		name string
 		input [][]byte
 		expected []byte
-		want bool
 	}{
 		{
 			"Empty Slice",
 			[][]byte{},
 			nil,
-			true,
 		},
 		{
 			"Size One Slice",
 			[][]byte{[]byte("transaction")},
 			New(New([]byte("transaction"))),
-			true,
 		},
 		{
 			"Size Two Slice",
 			[][]byte{[]byte("transaction1"), []byte("transaction2")},
 			New(New(append(New(New([]byte("transaction1"))), New(New([]byte("transaction2")))...))),
-			true,
 
 		},
 		{
 			"Size Three Slice",
 			[][]byte{[]byte("transaction1"), []byte("transaction2"), []byte("transaction3")},
 			New(New(append(New(New(append(New(New([]byte("transaction1"))), New(New([]byte("transaction2")))...))), New(New(append(New(New([]byte("transaction3"))), New(New([]byte("transaction3")))...)))...))),
-			true,
 
 		},
 		{
 			"Size Four Slice",
 			[][]byte{[]byte("transaction1"), []byte("transaction2"), []byte("transaction3"), []byte("transaction4")},
 			New(New(append(New(New(append(New(New([]byte("transaction1"))), New(New([]byte("transaction2")))...))), New(New(append(New(New([]byte("transaction3"))), New(New([]byte("transaction4")))...)))...))),
-			true,
 
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if result := bytes.Equal(GetMerkleRootHash(tt.input),tt.expected); result != tt.want {
-				t.Errorf("Failed to return %v (got %v) for hashes that are: %v", tt.want, result, tt.name)
+			if !bytes.Equal(GetMerkleRootHash(tt.input),tt.expected) {
+				t.Errorf("Failed on %v - results are not equal", tt.name)
 			}
 		})
 	}

--- a/internal/hashing/hashing_test.go
+++ b/internal/hashing/hashing_test.go
@@ -21,56 +21,53 @@ func TestNew(t *testing.T) {
 }
 
 func TestGetMerkleRootHashInput(t *testing.T) {
-	input := [][]byte{}
-	expected := GetMerkleRootHash(input)
+	tests := []struct {
+		name string
+		input [][]byte
+		expected []byte
+		want bool
+	}{
+		{
+			"Empty Slice",
+			[][]byte{},
+			nil,
+			true,
+		},
+		{
+			"Size One Slice",
+			[][]byte{[]byte("transaction")},
+			New(New([]byte("transaction"))),
+			true,
+		},
+		{
+			"Size Two Slice",
+			[][]byte{[]byte("transaction1"), []byte("transaction2")},
+			New(New(append(New(New([]byte("transaction1"))), New(New([]byte("transaction2")))...))),
+			true,
 
-	if len(input) != len(expected) {
-		t.Errorf("Error! GetMerkelRootHash does not return an empty slice on input of empty slice")
+		},
+		{
+			"Size Three Slice",
+			[][]byte{[]byte("transaction1"), []byte("transaction2"), []byte("transaction3")},
+			New(New(append(New(New(append(New(New([]byte("transaction1"))), New(New([]byte("transaction2")))...))), New(New(append(New(New([]byte("transaction3"))), New(New([]byte("transaction3")))...)))...))),
+			true,
+
+		},
+		{
+			"Size Four Slice",
+			[][]byte{[]byte("transaction1"), []byte("transaction2"), []byte("transaction3"), []byte("transaction4")},
+			New(New(append(New(New(append(New(New([]byte("transaction1"))), New(New([]byte("transaction2")))...))), New(New(append(New(New([]byte("transaction3"))), New(New([]byte("transaction4")))...)))...))),
+			true,
+
+		},
 	}
 
-	input = [][]byte{[]byte("transaction")}
-	expected = New(New(input[0]))
-	actual := GetMerkleRootHash(input)
-
-	if !bytes.Equal(expected, actual) {
-		t.Errorf("Error! GetMerkelRootHash does not produce correct result on single byte slice")
-		t.Errorf("Expected != Actual")
-		t.Errorf("%v != %v", expected, actual)
-	}
-
-	input = [][]byte{[]byte("transaction1"), []byte("transaction2")}
-	concat := append(New(New(input[0])), New(New(input[1]))...)
-	expected = New(New(concat))
-	actual = GetMerkleRootHash(input)
-
-	if !bytes.Equal(expected, actual) {
-		t.Errorf("Error! GetMerkelRootHash does not produce correct result on two byte slices")
-		t.Errorf("Expected != Actual")
-		t.Errorf("%v != %v", expected, actual)
-	}
-
-	input = [][]byte{[]byte("transaction1"), []byte("transaction2"), []byte("transaction3")}
-	concat1 := New(New(append(New(New(input[0])), New(New(input[1]))...)))
-	concat2 := New(New(append(New(New(input[2])), New(New(input[2]))...)))
-	expected = New(New(append(concat1, concat2...)))
-	actual = GetMerkleRootHash(input)
-
-	if !bytes.Equal(expected, actual) {
-		t.Errorf("Error! GetMerkelRootHash does not produce correct result on three byte slices")
-		t.Errorf("Expected != Actual")
-		t.Errorf("%v != %v", expected, actual)
-	}
-
-	input = [][]byte{[]byte("transaction1"), []byte("transaction2"), []byte("transaction3"), []byte("transaction4")}
-	concat1 = New(New(append(New(New(input[0])), New(New(input[1]))...)))
-	concat2 = New(New(append(New(New(input[2])), New(New(input[3]))...)))
-	expected = New(New(append(concat1, concat2...)))
-	actual = GetMerkleRootHash(input)
-
-	if !bytes.Equal(expected, actual) {
-		t.Errorf("Error! GetMerkelRootHash does not produce correct result on three byte slices")
-		t.Errorf("Expected != Actual")
-		t.Errorf("%v != %v", expected, actual)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if result := bytes.Equal(GetMerkleRootHash(tt.input),tt.expected); result != tt.want {
+				t.Errorf("Failed to return %v (got %v) for hashes that are: %v", tt.want, result, tt.name)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Even though the tests have been consolidated, I would like to implement the tests in a slightly better way using a struct, something like this from another test:

My question is, would this be a cleaner way? I think so but don't want to waste time

tests := []struct {
		input [][]byte
		want  bool
	}{
		{
			[]byte{something},
			true,
		},

                  ...
}